### PR TITLE
Add timeout in "getPoseToObstacle"

### DIFF
--- a/stepback_and_steerturn_recovery/src/stepback_and_steerturn_recovery.cpp
+++ b/stepback_and_steerturn_recovery/src/stepback_and_steerturn_recovery.cpp
@@ -192,14 +192,20 @@ gm::Pose2D StepBackAndSteerTurnRecovery::getPoseToObstacle (const gm::Pose2D& cu
   double t; // Will hold the first time that is invalid
   gm::Pose2D current_tmp = current;
   double next_cost;
-
+  // Check Timeout
+  ros::Time time_begin = ros::Time::now();
+  const double time_out = step_back_timeout_;
   ROS_DEBUG_NAMED ("top", " ");
   for (t=simulation_inc_; t<=duration_ + 500; t+=simulation_inc_) {
-      ROS_DEBUG_NAMED ("top", "start loop");
-      current_tmp = forwardSimulate(current, twist, t);
-      ROS_DEBUG_NAMED ("top", "finish fowardSimulate");
-      next_cost = normalizedPoseCost(current_tmp);
-      ROS_DEBUG_NAMED ("top", "finish Cost");
+    if(time_begin + ros::Duration(time_out) < ros::Time::now())
+    {
+        break;
+    }
+    ROS_DEBUG_NAMED ("top", "start loop");
+    current_tmp = forwardSimulate(current, twist, t);
+    ROS_DEBUG_NAMED ("top", "finish fowardSimulate");
+    next_cost = normalizedPoseCost(current_tmp);
+    ROS_DEBUG_NAMED ("top", "finish Cost");
     //if (next_cost > cost) {
     if (/*next_cost == costmap_2d::INSCRIBED_INFLATED_OBSTACLE ||*/ next_cost == costmap_2d::LETHAL_OBSTACLE) {
       ROS_DEBUG_STREAM_NAMED ("cost", "Cost at " << t << " and pose " << forwardSimulate(current, twist, t)


### PR DESCRIPTION
#1 のissue対応です。
'stepback_and_steerturn_recovery' を使用した際にmove_baseが落ちる問題を解決しました。
原因はstepback_and_steerturn_recovery.cppファイル内のgetPoseToObstacle関数でfor文が無限ループしているのが原因でした。該当するfor文がどういう条件で無限ループに入るのか判別は出来ておりませんが、タイムアウトを監視する形で強制的にfor文を抜けるようにしました。

