### PR TITLE
[bugfix](stepbeck)worldToMap function

### DIFF
--- a/stepback_and_steerturn_recovery/src/stepback_and_steerturn_recovery.cpp
+++ b/stepback_and_steerturn_recovery/src/stepback_and_steerturn_recovery.cpp
@@ -171,10 +171,10 @@ double StepBackAndSteerTurnRecovery::normalizedPoseCost (const gm::Pose2D& pose)
   p.x = pose.x;
   p.y = pose.y;
 
-  unsigned int pose_map_idx_x, pose_map_idx_y;
+  int pose_map_idx_x, pose_map_idx_y;
   costmap_2d::Costmap2D* costmap = local_costmap_->getCostmap();
-  costmap->worldToMap(p.x, p.y, pose_map_idx_x, pose_map_idx_y);  // convert point unit from [m] to [idx]
-  ROS_DEBUG_NAMED ("top", "Trying to get cost at (%d, %d) in getCost", pose_map_idx_x, pose_map_idx_y);
+  costmap->worldToMapEnforceBounds(p.x, p.y, pose_map_idx_x, pose_map_idx_y);  // convert point unit from [m] to [idx]
+  ROS_DEBUG_NAMED ("top", "Trying to get cost at (%f, %f - > %d, %d) in getCost", p.x, p.y, pose_map_idx_x, pose_map_idx_y);
   const double c = costmap->getCost(pose_map_idx_x, pose_map_idx_y);
 
   return c < 0 ? 1e9 : c;


### PR DESCRIPTION
__Summary__
  worldToMap -> worldToMapEnforceBoundsに関数を修正
* Detail
  - 異常終了する箇所を指差呼称すると`costmap ->
    worldToMap`の箇所で変換後に異常な座標点に変換していた
https://github.com/sbgisen/steer_drive_ros/blob/53ecca6c35cdbe05c3da386d46476105b5d8db3d/stepback_and_steerturn_recovery/src/stepback_and_steerturn_recovery.cpp#L176
![2020-08-21_11-32](https://user-images.githubusercontent.com/20681658/90848663-619e5a00-e3a8-11ea-8b28-f5e9a1978519.png)

  - [costmap_2d reference](http://docs.ros.org/indigo/api/costmap_2d/html/classcostmap__2d_1_1costmap2d.html#ab7134df329c4d4c174297f5db070c5a5)を見ると、変換後の座標がMap内にあることを保証してくれる`worldToMapEnforceBounds`があったので変更
  - 自分のGazebo環境では落ちなくなりました

* Refs
https://github.com/sbgisen/cube/issues/427
* Change files
  - modified:   src/stepback_and_steerturn_recovery.cpp